### PR TITLE
Update initial_request.text.erb

### DIFF
--- a/lib/views/outgoing_mailer/initial_request.text.erb
+++ b/lib/views/outgoing_mailer/initial_request.text.erb
@@ -1,4 +1,4 @@
-<%= @outgoing_message.body.strip %>
+<%= raw @outgoing_message.body.strip %>
 
 -------------------------------------------------------------------
 


### PR DESCRIPTION
Use the raw helper so that characters like ' are not HTML escaped in outgoing email messages.  This is already done in the initial_request.text.erb shipped with Alaveteli.
