### PR TITLE
Reduce potential confusion by using placeholder selectors for menu item styles

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -53,7 +53,7 @@ $action-border: #d69457;
 }
 
 /* General styling of nav menu items */
-.menu-item {
+%menu-item {
   text-decoration: none;
   background-color: $main_menu-link_bg;
   color: transparentize($main_menu-link_text, 0.2);
@@ -70,7 +70,7 @@ $action-border: #d69457;
 }
 
 /* Selected menu item */
-.selected-menu-item {
+%selected-menu-item {
   font-weight: bold;
   color: $main_menu-active_link_text;
   background-color: $main_menu-active_link_bg;
@@ -80,7 +80,7 @@ $action-border: #d69457;
 }
 
 /* Styling if not part of the main menu on larger screens */
-.sub-menu-item {
+%sub-menu-item {
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     background-color: $banner_bg;
     color: $submenu-color;
@@ -216,11 +216,11 @@ a.link_button_green_large {
 #navigation{
   border-bottom: none;
   a {
-    @extend .menu-item;
+    @extend %menu-item;
   }
   /* Show which section is currently selected */
   li.selected a{
-    @extend .selected-menu-item;
+    @extend %selected-menu-item;
   }
 
   /* Vertically align the search box */
@@ -301,8 +301,8 @@ a.link_button_green_large {
 /* Logged and local options act like submenus */
 #logged_in_bar{
   a {
-    @extend .menu-item;
-    @extend .sub-menu-item;
+    @extend %menu-item;
+    @extend %sub-menu-item;
     font-weight: normal;
   }
   #logged_in_links {
@@ -324,7 +324,7 @@ a.link_button_green_large {
     right: 15px;
   }
   a {
-    @extend .menu-item;
+    @extend %menu-item;
     font-family: $sans-serif-font-family;
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       padding: 0.5em 0.2em;


### PR DESCRIPTION
I'm working on a slightly customised version of this theme for a customer. I spent a while trying to work out where `.menu-item`, `.menu-item-hover`, and `.sub-menu-item` appeared in the Alaveteli source code, since the selectors' presence in the [sass file](https://github.com/mysociety/alavetelitheme/blob/7b290c301aad8bb078b7e95b492d9a2936a6c58e/assets/stylesheets/responsive/custom.scss#L56) suggested elements with those classes actually exist somewhere on the site.

```
/* General styling of nav menu items */
.menu-item {
  text-decoration: none;
  …
}

/* Selected menu item */
.selected-menu-item {
  font-weight: bold;
  …
}

/* Styling if not part of the main menu on larger screens */
.sub-menu-item {
  @include respond-min( $main_menu-mobile_menu_cutoff ){
    …
  }
}
```

As it turns out, there are no elements with those classes – they're only defined to be extended later on in the file.

Since Sass 3.2, it's become best practice to [define such styles as "placeholders"](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#placeholders), with a selector beginning with a `%`. Styles defined this way won't be compiled into the stylesheet unless they're extended. But more usefully, the `%` at the beginning is a clear sign to developers that the style is made to be _extended_ rather than used in HTML directly.
