### PR TITLE
Update for compatibility with new core user nav styles

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -321,6 +321,10 @@ a.link_button_green_large {
 
 /* Logged and local options act like submenus */
 #logged_in_bar{
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    top: 0;
+  }
+
   a {
     @extend %menu-item;
     background-color: transparent;
@@ -333,7 +337,6 @@ a.link_button_green_large {
     }
   }
   #logged_in_links {
-    top: 2em;
     a {
       font-weight: normal;
     }


### PR DESCRIPTION
The "logged_in_bar" in the core theme [now has a set width](https://github.com/mysociety/alaveteli/pull/3014), and uses absolute positioning to vertically align its children. Since Alavetelitheme moves the language picker to the left, we no longer need to leave 2em of vertical space for it in this theme.

Part of mysociety/alaveteli#2989.

![screen shot 2016-01-21 at 16 45 09](https://cloud.githubusercontent.com/assets/739624/12487285/70ac6d10-c05e-11e5-9da5-984cc385a68e.png)