### PR TITLE
Allow language switcher dropdown to expand horizontally

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -421,7 +421,7 @@ a.link_button_green_large {
     z-index: 1000;
     border-radius: 3px;
     font-size: 1em;
-    width: 100%;
+    min-width: 100%;
   }
 
 }


### PR DESCRIPTION
Handy for displaying languages with very long names!

Part of mysociety/alaveteli#2989.

Before:

![before](https://cloud.githubusercontent.com/assets/739624/12507671/269a34b4-c0ef-11e5-9e3b-c3950f9a70fa.png)

After:

![after](https://cloud.githubusercontent.com/assets/739624/12507674/29554c2a-c0ef-11e5-8fd2-69e1a12f0d41.png)

