### PR TITLE
Styling for the .correspondence_delivery fold-out

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -616,6 +616,11 @@ div.correspondence {
   }
 }
 
+.correspondence_delivery {
+  // TODO: Different background colours for different statuses
+  background-color: mix($status-success, $color_neutral_light, 15%);
+}
+
 .describe_state_form input[type="radio"] + label {
   display:inline;
 }


### PR DESCRIPTION
Styling for the new `.correspondence_delivery` element from https://github.com/mysociety/alaveteli/pull/3222.

![delivery2](https://cloud.githubusercontent.com/assets/739624/14812936/5366a37c-0b97-11e6-8223-234d1788b0ca.gif)