### PR TITLE
[#3293] Add request reporting sections to the help/about page

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -32,6 +32,34 @@
       it must be kept confidential.
     </dd>
 
+    <dt id="reporting">What if I see a request I feel to be inappropriate? <a href="#reporting">#</a></dt>
+    <dd>
+      <p>
+        Requests for personal information and vexatious requests are not considered valid for FOI purposes (read more).
+      </p>
+
+      <p>
+        If you believe a request is not suitable, you can report it for attention by the site administrators.
+      </p>
+    </dd>
+
+    <dt id="reporting_unavailable">Why won't it let me report some requests? <a href="#reporting_unavailable">#</a></dt>
+    <dd>
+      <p>
+        If a request has already been reported to the site administrators, you
+        can't report it a second time - this is to prevent the administrators
+        being notified multiple times about the same issue before they've had
+        a chance to conduct a review.
+      </p>
+
+      <p>
+        Where a request has been previously reported but an administrator has
+        chosen not to hide it from public view, you can use the form in the
+        sidebar of the request page to contact the administrators if you still
+        think it should be hidden.
+      </p>
+    </dd>
+
     <dt id="who">Who makes <%= site_name %> ? <a href="#who">#</a> </dt>
     <dd><%= site_name %> runs on <a href="http://alaveteli.org">Alaveteli</a>, which was created and run by <a href="http://www.mysociety.org">mySociety</a>,
       and was initially <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/">funded by the JRSST Charitable Trust</a>. mySociety is a project of the


### PR DESCRIPTION
Connects to  [#3293](https://github.com/mysociety/alaveteli/issues/3293)

Depends on [#3451](https://github.com/mysociety/alaveteli/pull/3451)