### PR TITLE
Overridable default letter

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -10,6 +10,10 @@ Rails.configuration.to_prepare do
   # OutgoingMessage.class_eval do
   #   # Add intro paragraph to new request template
   #   def default_letter
+  #     # this line allows the default_letter text added by this
+  #     # method to be replaced by the value supplied by the API
+  #     # e.g. http://demo.alaveteli.org/new/tgq?default_letter=this+is+a+test
+  #     return @default_letter if @default_letter
   #     return nil if self.message_type == 'followup'
   #     "If you uncomment this line, this text will appear as default text in every message"
   #   end


### PR DESCRIPTION
Getting the URL param override to work when patching `OutgoingMessage#default_letter` is a bit weird - and you can't get away with just adding `super` because we're reopening the method, not an inheriting it - so now that I've worked it out, I've added it to the example code.

With this in place, the theme's customised default_letter text will appear unless `default_letter` is passed in via the URL. If the theme code should always be in effect, commenting this line out will mean that the param value is ignored.

The extra comment char in 2fbc7c9 is for me as I keep getting the editor to uncomment the whole block and wondering what went wrong.

Connects to mysociety/alaveteli/issues/3615