### PR TITLE
[#85] correspondence date link colour

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -550,7 +550,7 @@ div.correspondence {
 
 .incoming.correspondence {
   border-top: 8px solid $color_secondary;
-  a {
+  .correspondence_text a {
     color: $color_secondary;
   }
   a.link_to_this {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -565,6 +565,11 @@ div.correspondence {
   }
 }
 
+a.correspondence__header__date,
+a.correspondence__header__date:visited {
+  color: #777;
+}
+
 .describe_state_form input[type="radio"] + label {
   display:inline;
 }


### PR DESCRIPTION
Fixes #85

Before:

![screen shot 2016-12-06 at 13 28 28](https://cloud.githubusercontent.com/assets/282788/20927139/10cc7308-bbb8-11e6-8797-c75eb5c55626.png)

After:

![screen shot 2016-12-06 at 13 29 16](https://cloud.githubusercontent.com/assets/282788/20927142/14ba292e-bbb8-11e6-833c-ce09ca9f8f51.png)
