### PR TITLE
[#83] Make request status text black

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -650,6 +650,10 @@ a.link_to_this {
   color: $status-success;
 }
 
+.request-status-message {
+  color: $color_black;
+}
+
 /* Attachments*/
 
 .view_html_prefix {


### PR DESCRIPTION
Otherwise there's not enough contrast between it and the new colour
background.

Fixes https://github.com/mysociety/alavetelitheme/issues/83.

![screen shot 2016-12-12 at 16 31 16](https://cloud.githubusercontent.com/assets/282788/21107089/6c8b622e-c088-11e6-90f5-b363301cc7c4.png)
