### PR TITLE
[Rails 5] Use before_action instead of before_filter

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -9,7 +9,7 @@ class ActionController::Base
   # template to use for a view.  It does so by creating a method
   # uniquely named for this theme.
   path_function_name = "set_view_paths_for_#{THEME_NAME}"
-  before_filter path_function_name.to_sym
+  before_action path_function_name.to_sym
   send :define_method, path_function_name do
     self.prepend_view_path File.join(File.dirname(__FILE__), "views")
   end


### PR DESCRIPTION
## Relevant issue(s)

Required by mysociety/alaveteli#3969

## What does this do?

Prevents Rails 5 from raising a deprecation warning.
Supported by Rails 4.

## Why was this needed?

Affecting spec output in core

## Note to self/merger

When this gets merged, tag it with use-with-alaveteli-0.32.0.0 to that Travis picks it up (Rail 4.2 safe)