### PR TITLE
[Rails 5] Allow Rails 5 to load theme assets correctly

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -35,16 +35,6 @@ end
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'
 
-# Prepend the asset directories in this theme to the asset path:
-['stylesheets', 'images', 'javascripts'].each do |asset_type|
-  theme_asset_path = File.join(File.dirname(__FILE__),
-                               '..',
-                               'app',
-                               'assets',
-                               asset_type)
-  Rails.application.config.assets.paths.unshift theme_asset_path
-end
-
 # Append individual theme assets to the asset path
 theme_asset_path = File.join(File.dirname(__FILE__),
                              '..',
@@ -56,8 +46,25 @@ LOOSE_THEME_ASSETS = lambda do |logical_path, filename|
   filename.start_with?(theme_asset_path) &&
   !['.js', '.css', ''].include?(File.extname(logical_path))
 end
-
 Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)
+
+def append_theme_assets
+  # Prepend the asset directories in this theme to the asset path:
+  ['stylesheets', 'images', 'javascripts'].each do |asset_type|
+    theme_asset_path = File.join(File.dirname(__FILE__),
+                                 '..',
+                                 'app',
+                                 'assets',
+                                 asset_type)
+    Rails.application.assets.prepend_path theme_asset_path
+    # for completeness / to avoid confusion
+    Rails.application.config.assets.paths = Rails.application.assets.paths
+  end
+end
+
+Rails.application.config.after_initialize do
+  append_theme_assets
+end
 
 # Tell FastGettext about the theme's translations: look in the theme's
 # locale-theme directory for a translation in the first place, and if


### PR DESCRIPTION
## Relevant issue(s)

Closes mysociety/alaveteli#5093
Required by https://github.com/mysociety/alaveteli/issues/3969

## What does this do?

Moves the code - with a minor change to the variable name - to prepend the theme assets to the Sprockets asset paths into an `Rails.application.config.after_initialize` block.

## Why was this needed?

For compatibility with Rails 5 - something about the boot sequence has changed, causing the initialisation of the asset paths to occur after all the `config/initialize` code has run (have not tested exhaustively but it appears to happen during `Rails.application.initialize!`; others have reached a [similar conclusion](https://github.com/rails/sprockets/issues/458#issuecomment-275907083)).

Without this change, we "prepend" our custom asset paths to an empty array and all the defaults get prepended afterwards so our intended overrides finish up at the end of the array, searched last and unable to override anything.

## Implementation notes

This is the simplest version in terms of least changes to the theme code for reusers. However, there is a potential gotcha in that - for reasons I've not dug into but it appears to be a scope problem - if we continue to name the variable name inside the `after_initialize` block `theme_asset_paths`, it conflicts with the `LOOSE_ASSET_PATHS` code (which uses the same variable name - something to do with it being a lambda/proc?), causing 'asset not precompiled' errors.

We could fix this - at the expense of making more changes to the theme - and end up with something like this instead (restricts the variable name to a method scope) ...

```rb
def append_theme_assets
  # Prepend the asset directories in this theme to the asset path:
  ['stylesheets', 'images', 'javascripts'].each do |asset_type|
    theme_asset_path = File.join(File.dirname(__FILE__),
                                 '..',
                                 'app',
                                 'assets',
                                 asset_type)
    Rails.application.assets.prepend_path theme_asset_path
    # for completeness / to avoid confusion
    Rails.application.config.assets.paths = Rails.application.assets.paths
  end
end

Rails.application.config.after_initialize do
  append_theme_assets
end
```

## Notes to reviewer

Works best tested against the [rails5/rollup](https://github.com/mysociety/alaveteli/tree/rails5/rollup) branch