### PR TITLE
[Rails 5] Use the Rails config.to_prepare hook to load the theme assets

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -35,16 +35,6 @@ end
 # something unique (e.g. yourtheme-custom-routes.rb":
 $alaveteli_route_extensions << 'custom-routes.rb'
 
-# Prepend the asset directories in this theme to the asset path:
-['stylesheets', 'images', 'javascripts'].each do |asset_type|
-  theme_asset_path = File.join(File.dirname(__FILE__),
-                               '..',
-                               'app',
-                               'assets',
-                               asset_type)
-  Rails.application.config.assets.paths.unshift theme_asset_path
-end
-
 # Append individual theme assets to the asset path
 theme_asset_path = File.join(File.dirname(__FILE__),
                              '..',
@@ -56,8 +46,24 @@ LOOSE_THEME_ASSETS = lambda do |logical_path, filename|
   filename.start_with?(theme_asset_path) &&
   !['.js', '.css', ''].include?(File.extname(logical_path))
 end
-
 Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)
+
+def prepend_theme_assets
+  # Prepend the asset directories in this theme to the asset path:
+  ['stylesheets', 'images', 'javascripts'].each do |asset_type|
+    theme_asset_path = File.join(File.dirname(__FILE__),
+                                 '..',
+                                 'app',
+                                 'assets',
+                                 asset_type)
+
+    Rails.application.config.assets.paths.unshift theme_asset_path
+  end
+end
+
+Rails.application.config.to_prepare do
+  prepend_theme_assets
+end
 
 # Tell FastGettext about the theme's translations: look in the theme's
 # locale-theme directory for a translation in the first place, and if


### PR DESCRIPTION
## Relevant issue(s)

Closes mysociety/alaveteli#5093

## What does this do?

Moves the code to prepend the theme assets to `Rails.application.config.assets.paths` into a method that's called from a `Rails.application.config.to_prepare` block (so that it's called at the right point in the boot-up process - inside an `initializers/*.rb` file is too early, the `Rails.application.config.after_initialize` hook may be too late, depending on other settings).

## Why was this needed?

Rails 5 has introduced changes to the load order so now
`Rails.application.config.assets.paths` is populated later - as part of
the initialization process - so when our original code tries to prepend
theme paths from `initializers/theme_loader.rb`, it is adding to an
empty array which results in our custom paths being the last to be
searched after the Rails and core app paths have been loaded.

The `after_initialize` hook is too late as - if caching is in effect -
the Sprockets environment has been cached at this point (and the path
array is frozen), and changing `Rails.application.config.assets` has no
effect. As `Rails.config.to_prepare` runs after the initializers but
while changes can still be made and only runs once (at boot-up) in
production so it should be a good choice:

https://guides.rubyonrails.org/configuring.html#initializers