### PR TITLE
Resolve Internal Server Error when rendering /help/requesting

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -160,13 +160,13 @@
         </li>
         <li>If you're still having no luck, then you can ask for an internal review,
           and then complain to the Information Commissioner about the authority.
-          Read our page '<a href="<%= help_general_path(:action => 'unhappy') %>">Unhappy about the response you got?</a>'.
+          Read our page '<a href="<%= help_general_path(:template => 'unhappy') %>">Unhappy about the response you got?</a>'.
       </ul>
     </dd>
 
     <dt id="not_satifised">What if I'm not satisfied with the response? <a href="#not_satifised">#</a> </dt>
     <dd>If you didn't get the information you asked for, or you didn't get it in time,
-      then read our page '<a href="<%= help_general_path(:action => 'unhappy') %>">Unhappy about the response you got?</a>'.
+      then read our page '<a href="<%= help_general_path(:template => 'unhappy') %>">Unhappy about the response you got?</a>'.
     </dd>
 
     <dt id="reuse">It says I can't re-use the information I got!<a href="#reuse">#</a> </dt>


### PR DESCRIPTION
The changes introduced in mysociety/alaveteli@50f9f33269aa223b7e1178dac1d18a23dcdccbf7 were not reflected in alavetelitheme which means sites directly using this template would encounter the following exception:

No route matches {:action=>"unhappy", :controller=>"help"} missing required keys: [:template]