### PR TITLE
Issues/6363 extract reply button

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -624,6 +624,14 @@ p.locale-list-trigger {
   @include follower-count();
 }
 
+.action-bar__reply {
+  .action-bar__reply-button {
+    @include button-primary();
+    color: #fff;
+  }
+}
+
+
 div.correspondence {
   background-color: $color_white;
   box-shadow: 0 2px 2px transparentize($color_black, 0.8);

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1,4 +1,3 @@
-
 /* Mixin styles */
 
 /* Hide text when it's replaced by an image */
@@ -602,25 +601,27 @@ p.locale-list-trigger {
 }
 
 /* Request page */
-.request-header__action-bar__actions {
+.after-actions {
   .action-menu__button {
     @include button-secondary();
+    padding-right: 1.5em;
     &:after {
       border-color: #a5a5a5 transparent transparent transparent;
       right: 7%;
     }
   }
+}
 
-  .action-bar__follow-button {
-    .track__action {
-      @include button-primary();
-      @include follow-button();
-    }
-  }
 
-  .action-bar__follower-count {
-    @include follower-count();
+.action-bar__follow-button {
+  .track__action {
+    @include button-primary();
+    @include follow-button();
   }
+}
+
+.action-bar__follower-count {
+  @include follower-count();
 }
 
 div.correspondence {
@@ -714,6 +715,7 @@ a.link_to_this {
     in Alaveteli core. When this is fixed it can be removed.
   */
 }
+
 
 /* Status lines and icons */
 .icon_waiting_classification,


### PR DESCRIPTION
Styles ready for https://github.com/mysociety/alaveteli/pull/6455

Also adds missing styles from when the action button was added to the bottom of the message thread in https://github.com/mysociety/alaveteli/issues/3649