### PR TITLE
[Notes] Erased styling for #request_header_text

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -345,7 +345,7 @@ a.link_button_green_large {
 }
 /* Notices, errors */
 
-#notice, #error, .errorExplanation, #request_header_text, #hidden_request, .describe_state_form form, .undescribed_requests, .warning {
+#notice, #error, .errorExplanation, #hidden_request, .describe_state_form form, .undescribed_requests, .warning {
   border-top: 10px solid;
   font-size: 1em;
   margin:1em 0;
@@ -364,7 +364,7 @@ a.link_button_green_large {
   }
 }
 
-#notice, #request_header_text {
+#notice {
   background-color: desaturate(lighten($notice-color, 30%),10%);
   border-color: $notice-color;
 }


### PR DESCRIPTION
Erased styling for `#request_header_text` element. It was causing issues on the new request page. This issue was only on this theme.

[Part of this PR](https://github.com/mysociety/alaveteli/pull/7258)
### Before
<img width="1012" alt="Screenshot 2022-08-31 at 12 11 37" src="https://user-images.githubusercontent.com/13790153/187671278-82d8ea9c-9e42-4214-bc30-3a551214e08b.png">

### After
<img width="1012" alt="Screenshot 2022-08-31 at 12 39 04" src="https://user-images.githubusercontent.com/13790153/187670938-76be939c-336b-4261-9840-a964305b6011.png">

Let me know if you have any feedback
